### PR TITLE
chore: release v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "misaki-cli"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "misaki-core"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 description = "Fast, asynchronous link checker with optional FlareSolverr support."
 authors = ["Ravencentric <me@ravencentric.cc>"]
 readme = "README.md"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/Ravencentric/misaki/compare/v0.0.3...v0.0.4) - 2025-07-17
+
+### Fixed
+
+- readme
+- update readme
+- document panics
+
 ## [0.0.3](https://github.com/Ravencentric/misaki/compare/v0.0.2...v0.0.3) - 2025-07-17
 
 ### Fixed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { workspace = true, features = ["signal"]}
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 futures = { workspace = true }
-misaki-core = { version = "0.0.3", path = "../core" }
+misaki-core = { version = "0.0.4", path = "../core" }
 clap = { version = "4.5.41", features = ["derive"] }
 clap-stdin = "0.6.0"
 owo-colors = "4"

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/Ravencentric/misaki/compare/misaki-core-v0.0.3...misaki-core-v0.0.4) - 2025-07-17
+
+### Fixed
+
+- readme
+- update readme
+- document panics
+
 ## [0.0.2](https://github.com/Ravencentric/misaki/compare/misaki-core-v0.0.1...misaki-core-v0.0.2) - 2025-07-17
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `misaki-core`: 0.0.3 -> 0.0.4 (✓ API compatible changes)
* `misaki-cli`: 0.0.3 -> 0.0.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `misaki-core`

<blockquote>

## [0.0.4](https://github.com/Ravencentric/misaki/compare/misaki-core-v0.0.3...misaki-core-v0.0.4) - 2025-07-17

### Fixed

- readme
- update readme
- document panics
</blockquote>

## `misaki-cli`

<blockquote>

## [0.0.4](https://github.com/Ravencentric/misaki/compare/v0.0.3...v0.0.4) - 2025-07-17

### Fixed

- readme
- update readme
- document panics
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).